### PR TITLE
fix: issue with dense storage

### DIFF
--- a/dense.go
+++ b/dense.go
@@ -38,7 +38,7 @@ func (s denseStorage) sizeInBytes(settings *settings) int {
 func (s denseStorage) writeBytes(settings *settings, bytes []byte) {
 
 	byteOffset := 0
-	nWords := cap(bytes) / 8
+	nWords := len(bytes) / 8
 	for i := 0; i < nWords; i++ {
 		binary.BigEndian.PutUint64(bytes[byteOffset:], s[i])
 		byteOffset += 8
@@ -47,7 +47,7 @@ func (s denseStorage) writeBytes(settings *settings, bytes []byte) {
 	// deal with any remaining bytes.  the binary writing function above doesn't
 	// handle the case where there are not exactly 8 bytes to write.
 	remainder := cap(bytes) % 8
-	if remainder > 0 {
+	if remainder > 0 && nWords < len(s) {
 		lastWord := s[nWords]
 		for i := 0; i < remainder; i++ {
 			bytes[byteOffset+i] = byte(lastWord >> uint(64-(8*(i+1))))

--- a/dense.go
+++ b/dense.go
@@ -46,7 +46,7 @@ func (s denseStorage) writeBytes(settings *settings, bytes []byte) {
 
 	// deal with any remaining bytes.  the binary writing function above doesn't
 	// handle the case where there are not exactly 8 bytes to write.
-	remainder := cap(bytes) % 8
+	remainder := len(bytes) % 8
 	if remainder > 0 && nWords < len(s) {
 		lastWord := s[nWords]
 		for i := 0; i < remainder; i++ {


### PR DESCRIPTION
- The issue is the writeBytes of `dense` storage type uses `cap` to get word count to insert and because we are sending a pre defined slice with ore capacity. That caused an issue.
- I have changed it to use `len()` instead of `cap`. In the previous scenario since the `bytes` were directly initialized using: `make([]byte, sizeNeeded)`. Both `cap` and `len` are same.